### PR TITLE
Add SetNX

### DIFF
--- a/cache.go
+++ b/cache.go
@@ -10,6 +10,9 @@ type Cache interface {
 	// Set sets a single item to the backend
 	Set(key string, value interface{}) error
 
+	// SetNX sets a single item to the backend, only if it doesn't exist
+	SetNX(key string, value interface{}) (bool, error)
+
 	// Delete deletes single item from backend
 	Delete(key string) error
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -102,12 +102,12 @@ func testCacheDelete(t *testing.T, cache Cache) {
 
 	err := cache.Delete("test_key3")
 	if err != nil {
-		t.Fatal("non-exiting item should not give error")
+		t.Fatal("non-existing item should not give error")
 	}
 
 	err = cache.Delete("test_key")
 	if err != nil {
-		t.Fatal("exiting item should not give error")
+		t.Fatal("existing item should not give error")
 	}
 
 	data, err := cache.Get("test_key")

--- a/helper_test.go
+++ b/helper_test.go
@@ -32,6 +32,44 @@ func testCacheGetSet(t *testing.T, cache Cache) {
 	}
 }
 
+func testCacheSetNX(t *testing.T, cache Cache) {
+	ok, err := cache.SetNX("test_key", "test_data")
+	if err != nil {
+		t.Fatal("should not give err while setting item")
+	}
+
+	if !ok {
+		t.Fatal("non-existing item should give true")
+	}
+
+	data, err := cache.Get("test_key")
+	if err != nil {
+		t.Fatal("test_key should be in the cache")
+	}
+
+	if data != "test_data" {
+		t.Fatal("data is not \"test_data\"")
+	}
+
+	ok, err = cache.SetNX("test_key", "test_data2")
+	if err != nil {
+		t.Fatal("should not give err while setting item")
+	}
+
+	if ok {
+		t.Fatal("existing item should give false")
+	}
+
+	data, err = cache.Get("test_key")
+	if err != nil {
+		t.Fatal("test_key should be in the cache")
+	}
+
+	if data != "test_data" {
+		t.Fatal("data is not \"test_data\"")
+	}
+}
+
 func testCacheNilValue(t *testing.T, cache Cache) {
 	err := cache.Set("test_key", nil)
 	if err != nil {

--- a/lru.go
+++ b/lru.go
@@ -41,6 +41,14 @@ func (l *LRU) Set(key string, val interface{}) error {
 	return l.cache.Set(key, val)
 }
 
+// SetNX sets a value to the cache only if it does not already exist
+func (l *LRU) SetNX(key string, val interface{}) (bool, error) {
+	l.Lock()
+	defer l.Unlock()
+
+	return l.cache.SetNX(key, val)
+}
+
 // Delete deletes the given key-value pair from cache, this function doesnt
 // return an error if item is not in the cache
 func (l *LRU) Delete(key string) error {

--- a/lru_nots.go
+++ b/lru_nots.go
@@ -99,35 +99,12 @@ func (l *LRUNoTS) Set(key string, val interface{}) error {
 
 // SetNX sets a value to the cache only if it does not already exist
 func (l *LRUNoTS) SetNX(key string, val interface{}) (bool, error) {
-	// try to get item
-	_, err := l.cache.Get(key)
-	if err != nil && err != ErrNotFound {
-		return false, err
-	}
-
-	var elem *list.Element
-
-	// if elem is not in the cache, push it to front of the list
+	_, err := l.Get(key)
 	if err == ErrNotFound {
-		elem = l.list.PushFront(&kv{k: key, v: val})
-	} else {
-		// if elem is already in the cache, do nothing
-		return false, nil
+		return true, l.Set(key, val)
 	}
 
-	// if elem is not in the cache, set the item to the cache
-	err = l.cache.Set(key, elem)
-	if err != nil {
-		return false, err
-	}
-
-	// if the cache is full, evict last entry
-	if l.list.Len() > l.size {
-		// remove last element from cache
-		return true, l.removeElem(l.list.Back())
-	}
-
-	return true, nil
+	return false, err
 }
 
 // Delete deletes the given key-value pair from cache, this function doesnt

--- a/lru_nots_test.go
+++ b/lru_nots_test.go
@@ -7,6 +7,11 @@ func TestLRUNoTSGetSet(t *testing.T) {
 	testCacheGetSet(t, cache)
 }
 
+func TestLRUNoTSSetNX(t *testing.T) {
+	cache := NewLRUNoTS(2)
+	testCacheSetNX(t, cache)
+}
+
 func TestLRUNoTSEviction(t *testing.T) {
 	cache := NewLRUNoTS(2)
 	testCacheGetSet(t, cache)
@@ -19,6 +24,16 @@ func TestLRUNoTSEviction(t *testing.T) {
 	_, err = cache.Get("test_key")
 	if err == nil {
 		t.Fatal("test_key should not be in the cache")
+	}
+
+	_, err = cache.SetNX("test_key4", "test_data4")
+	if err != nil {
+		t.Fatal("should not give err while setting item")
+	}
+
+	_, err = cache.Get("test_key2")
+	if err == nil {
+		t.Fatal("test_key2 should not be in the cache")
 	}
 }
 

--- a/lru_test.go
+++ b/lru_test.go
@@ -7,6 +7,11 @@ func TestLRUGetSet(t *testing.T) {
 	testCacheGetSet(t, cache)
 }
 
+func TestLRUSetNX(t *testing.T) {
+	cache := NewLRU(2)
+	testCacheSetNX(t, cache)
+}
+
 func TestLRUEviction(t *testing.T) {
 	cache := NewLRU(2)
 	testCacheGetSet(t, cache)
@@ -19,6 +24,16 @@ func TestLRUEviction(t *testing.T) {
 	_, err = cache.Get("test_key")
 	if err == nil {
 		t.Fatal("test_key should not be in the cache")
+	}
+
+	_, err = cache.SetNX("test_key4", "test_data4")
+	if err != nil {
+		t.Fatal("should not give err while setting item")
+	}
+
+	_, err = cache.Get("test_key2")
+	if err == nil {
+		t.Fatal("test_key2 should not be in the cache")
 	}
 }
 

--- a/memory.go
+++ b/memory.go
@@ -36,6 +36,14 @@ func (r *Memory) Set(key string, value interface{}) error {
 	return r.cache.Set(key, value)
 }
 
+// SetNX sets a value to the cache only if it does not already exist
+func (r *Memory) SetNX(key string, value interface{}) (bool, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	return r.cache.SetNX(key, value)
+}
+
 // Delete deletes the given key-value pair from cache, this function doesnt
 // return an error if item is not in the cache
 func (r *Memory) Delete(key string) error {

--- a/memory_nots.go
+++ b/memory_nots.go
@@ -34,13 +34,12 @@ func (r *MemoryNoTS) Set(key string, value interface{}) error {
 // SetNX will persist a value to the cache only
 // if it does not already exist
 func (r *MemoryNoTS) SetNX(key string, value interface{}) (bool, error) {
-	_, ok := r.items[key]
-	if ok {
-		return false, nil
-	} else {
-		r.items[key] = value
-		return true, nil
+	_, err := r.Get(key)
+	if err == ErrNotFound {
+		return true, r.Set(key, value)
 	}
+
+	return false, err
 }
 
 // Delete deletes a given key, it doesnt return error if the item is not in the

--- a/memory_nots.go
+++ b/memory_nots.go
@@ -31,6 +31,18 @@ func (r *MemoryNoTS) Set(key string, value interface{}) error {
 	return nil
 }
 
+// SetNX will persist a value to the cache only
+// if it does not already exist
+func (r *MemoryNoTS) SetNX(key string, value interface{}) (bool, error) {
+	_, ok := r.items[key]
+	if ok {
+		return false, nil
+	} else {
+		r.items[key] = value
+		return true, nil
+	}
+}
+
 // Delete deletes a given key, it doesnt return error if the item is not in the
 // system
 func (r *MemoryNoTS) Delete(key string) error {

--- a/memory_nots_test.go
+++ b/memory_nots_test.go
@@ -7,6 +7,11 @@ func TestMemoryCacheNoTSGetSet(t *testing.T) {
 	testCacheGetSet(t, cache)
 }
 
+func TestMemoryCacheNoTSSetNX(t *testing.T) {
+	cache := NewMemoryNoTS()
+	testCacheSetNX(t, cache)
+}
+
 func TestMemoryCacheNoTSDelete(t *testing.T) {
 	cache := NewMemoryNoTS()
 	testCacheDelete(t, cache)

--- a/memory_test.go
+++ b/memory_test.go
@@ -7,6 +7,11 @@ func TestMemoryGetSet(t *testing.T) {
 	testCacheGetSet(t, cache)
 }
 
+func TestMemorySetNX(t *testing.T) {
+	cache := NewMemory()
+	testCacheSetNX(t, cache)
+}
+
 func TestMemoryDelete(t *testing.T) {
 	cache := NewMemory()
 	testCacheDelete(t, cache)

--- a/memory_ttl.go
+++ b/memory_ttl.go
@@ -54,7 +54,7 @@ func (r *MemoryTTL) StartGC(gcInterval time.Duration) {
 }
 
 // Get returns a value of a given key if it exists
-// and valid for the time being
+// and is valid for the time being
 func (r *MemoryTTL) Get(key string) (interface{}, error) {
 	r.Lock()
 	defer r.Unlock()
@@ -78,9 +78,28 @@ func (r *MemoryTTL) Set(key string, value interface{}) error {
 	r.Lock()
 	defer r.Unlock()
 
+	r.set(key, value)
+	return nil
+}
+
+// SetNX will persist a value to the cache only
+// if it does not already exist
+func (r *MemoryTTL) SetNX(key string, value interface{}) (bool, error) {
+	r.Lock()
+	defer r.Unlock()
+
+	_, err := r.cache.Get(key)
+	if err == nil && r.isValid(key) {
+		return false, nil
+	}
+
+	r.set(key, value)
+	return true, nil
+}
+
+func (r *MemoryTTL) set(key string, value interface{}) {
 	r.cache.Set(key, value)
 	r.setAts[key] = time.Now()
-	return nil
 }
 
 // Delete deletes a given key if exists

--- a/memory_ttl_test.go
+++ b/memory_ttl_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 )
 
-func TestMemoryCacheGetSet(t *testing.T) {
+func TestMemoryCacheTTLGetSet(t *testing.T) {
 	cache := NewMemoryWithTTL(2 * time.Second)
 	cache.StartGC(time.Millisecond * 10)
 	cache.Set("test_key", "test_data")
@@ -18,7 +18,37 @@ func TestMemoryCacheGetSet(t *testing.T) {
 	}
 }
 
-func TestMemoryCacheTTL(t *testing.T) {
+func TestMemoryCacheTTLSetNX(t *testing.T) {
+	cache := NewMemoryWithTTL(2 * time.Second)
+	cache.StartGC(time.Millisecond * 10)
+	ok, _ := cache.SetNX("test_key", "test_data")
+	if !ok {
+		t.Fatal("non-existing item should give true")
+	}
+
+	data, err := cache.Get("test_key")
+	if err != nil {
+		t.Fatal("data not found")
+	}
+	if data != "test_data" {
+		t.Fatal("data is not \"test_data\"")
+	}
+
+	ok, _ = cache.SetNX("test_key", "test_data2")
+	if ok {
+		t.Fatal("existing item should give false")
+	}
+
+	data, err = cache.Get("test_key")
+	if err != nil {
+		t.Fatal("data not found")
+	}
+	if data != "test_data" {
+		t.Fatal("data is not \"test_data\"")
+	}
+}
+
+func TestMemoryCacheTTLExpiration(t *testing.T) {
 	cache := NewMemoryWithTTL(100 * time.Millisecond)
 	cache.StartGC(time.Millisecond * 10)
 	cache.Set("test_key", "test_data")


### PR DESCRIPTION
Hi buddies!

This PR adds the `SetNX` command to the `Cache` interface: similarly to `setnx` from [Redis](http://redis.io/commands/setnx), it sets the key only if it does not exists. I also implemented the method in all the caching backends.

As long as Go community does not adopt a standard way to manage dependencies, this could be a breaking change for all the projects that simply `go get` this library instead of _vendorizing_ it.

I'm pretty new to Go development, so I'm looking forward to know what do you think about the implementation and the dependency issue.