### PR TITLE
Race condition in memory TTL cache

### DIFF
--- a/sharded_ttl_test.go
+++ b/sharded_ttl_test.go
@@ -29,6 +29,32 @@ func TestShardedCacheTTL(t *testing.T) {
 	}
 }
 
+func TestShardedCacheTTLGetExpired(t *testing.T) {
+	// Needs go test -race to catch problems
+	cache := NewShardedWithTTL(1 * time.Millisecond)
+	cache.Set("user1", "test_key", "test_data")
+	sig := make(chan struct{})
+	go func() {
+		for {
+			_, _ = cache.Get("user1", "test_key")
+			select {
+			case _, ok := <-sig:
+				if !ok {
+					break
+				}
+			default:
+			}
+		}
+
+	}()
+	time.Sleep(20 * time.Millisecond)
+	_, err := cache.Get("user1", "test_key")
+	if err == nil {
+		t.Fatal("data found")
+	}
+	close(sig)
+}
+
 func TestShardedCacheTTLNilValue(t *testing.T) {
 	cache := NewShardedWithTTL(100 * time.Millisecond)
 	cache.StartGC(time.Millisecond * 10)


### PR DESCRIPTION
Added test to catch the error. Needs `go test -race`

Sharded TTL does not have the same problem as it 
uses a plain mutex.