### PR TITLE
Mongo cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: go
 
 sudo: false
 
+services:
+  - mongodb
+
 install:
   - go get -t -v ./...
 

--- a/doc.go
+++ b/doc.go
@@ -10,5 +10,5 @@
 //     ShardedTTL  : provides a thread safe, expiring in-memory sharded cache system, built on top of ShardedNoTS over MemoryNoTS
 //     LFUNoTS     : provides a non-thread safe, fixed size in-memory caching system, built on top of MemoryNoTS cache
 //     LFU         : provides a thread safe, fixed size in-memory caching system, built on top of LFUNoTS cache
-
+//
 package cache

--- a/lfu.go
+++ b/lfu.go
@@ -11,7 +11,7 @@ type LFU struct {
 	cache Cache
 }
 
-// NewLRU creates a thread-safe LRU cache
+// NewLFU creates a thread-safe LFU cache
 func NewLFU(size int) Cache {
 	return &LRU{
 		cache: NewLFUNoTS(size),

--- a/lfu.go
+++ b/lfu.go
@@ -2,6 +2,7 @@ package cache
 
 import "sync"
 
+// LFU holds the Least frequently used cache values
 type LFU struct {
 	// Mutex is used for handling the concurrent
 	// read/write requests for cache

--- a/lfu_nots.go
+++ b/lfu_nots.go
@@ -2,6 +2,7 @@ package cache
 
 import "container/list"
 
+// LFUNoTS holds the cache struct
 type LFUNoTS struct {
 	// list holds all items in a linked list
 	frequencyList *list.List
@@ -32,7 +33,7 @@ type cacheItem struct {
 	freqElement *list.Element
 }
 
-// NewLRUNoTS creates a new LFU cache struct for further cache operations. Size
+// NewLFUNoTS creates a new LFU cache struct for further cache operations. Size
 // is used for limiting the upper bound of the cache
 func NewLFUNoTS(size int) Cache {
 	if size < 1 {
@@ -197,7 +198,7 @@ func (l *LFUNoTS) evict(e *list.Element) error {
 	}
 
 	// remove the first item of the linked list
-	for entry, _ := range e.Value.(*entry).listEntry {
+	for entry := range e.Value.(*entry).listEntry {
 		l.cache.Delete(entry.k)
 		l.remove(entry, e)
 		l.currentSize--

--- a/lfu_nots_test.go
+++ b/lfu_nots_test.go
@@ -19,11 +19,11 @@ func TestLFUNoTSUsageWithSet(t *testing.T) {
 	// test_key3 is used 3 times
 	// test_key2 is used 2 times
 	// test_key1 is used 1 times
-	data, err := cache.Get("test_key1")
+	_, err := cache.Get("test_key1")
 	if err != ErrNotFound {
 		t.Fatal("test_key1 should not be in the cache")
 	}
-	data, err = cache.Get("test_key2")
+	data, err := cache.Get("test_key2")
 	if err != nil {
 		t.Fatal("test_key2 should be in the cache")
 	}
@@ -74,7 +74,7 @@ func TestLFUNoTSUsageWithSetAndGet(t *testing.T) {
 	}
 	// set test_key4 into cache list
 	// test_key1 should not be in cache list
-	if err := cache.Set("test_key4", "test_data4"); err != nil {
+	if err = cache.Set("test_key4", "test_data4"); err != nil {
 		t.Fatal("test_key4 should be set")
 	}
 
@@ -110,7 +110,7 @@ func TestLFUNoTSDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal("test_key3 should be in the cache")
 	}
-	if err := cache.Delete("test_key1"); err != nil {
+	if err = cache.Delete("test_key1"); err != nil {
 		t.Fatal("test_key1 should be deleted")
 	}
 

--- a/memory_nots.go
+++ b/memory_nots.go
@@ -13,9 +13,10 @@ func NewMemoryNoTS() *MemoryNoTS {
 	}
 }
 
-// Helper method to return a Cache interface, so callers don't have to typecast
+// NewMemNoTSCache is a helper method to return a Cache interface, so callers
+// don't have to typecast
 func NewMemNoTSCache() Cache {
-        return NewMemoryNoTS()
+	return NewMemoryNoTS()
 }
 
 // Get returns a value of a given key if it exists

--- a/memory_ttl_test.go
+++ b/memory_ttl_test.go
@@ -8,6 +8,7 @@ import (
 func TestMemoryCacheGetSet(t *testing.T) {
 	cache := NewMemoryWithTTL(2 * time.Second)
 	cache.StartGC(time.Millisecond * 10)
+	defer cache.StopGC()
 	cache.Set("test_key", "test_data")
 	data, err := cache.Get("test_key")
 	if err != nil {

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -1,0 +1,48 @@
+package cache
+
+import "time"
+
+// MongoCache...
+type MongoCache struct {
+	mongeSession *mgo.Session
+	// cache holds the cache data
+	cache *KeyValue
+
+	// ttl is a duration for a cache key to expire
+	ttl time.Duration
+}
+
+func NewMongoCacheWithTTL(session *mgo.Session, ttl time.Duration) *MongoCache {
+	return &MongoCache{
+		mongeSession: session,
+		cache:        &KeyValue{},
+		ttl:          ttl,
+	}
+}
+
+// Get returns a value of a given key if it exists
+func (m *MongoCache) Get(key string) (interface{}, error) {
+	return m.GetKeyWithExpireCheck(key)
+}
+
+// Set will persist a value to the cache or
+// override existing one with the new one
+func (m *MongoCache) Set(key string, value interface{}) error {
+	return m.set(key, value)
+}
+
+// Delete deletes a given key if exists
+func (m *MongoCache) Delete(key string) error {
+	return m.DeleteKey(key)
+}
+
+func (m *MongoCache) set(key string, value interface{}) error {
+	kv := &KeyValue{
+		Key:       key,
+		Value:     value,
+		CreatedAt: time.Now().UTC(),
+		ExpireAt:  time.Now().UTC().Add(m.ttl),
+	}
+
+	return m.CreateKeyValueWithExpiration(kv)
+}

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -1,6 +1,10 @@
 package cache
 
-import "time"
+import (
+	"time"
+
+	mgo "gopkg.in/mgo.v2"
+)
 
 // MongoCache...
 type MongoCache struct {

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -106,8 +106,6 @@ func (m *MongoCache) StartGCol(gcInterval time.Duration) {
 		for {
 			select {
 			case <-ticker.C:
-				now := time.Now()
-
 				m.Lock()
 				m.DeleteExpiredKeys()
 				m.Unlock()

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -83,11 +83,15 @@ func NewMongoCacheWithTTL(session *mgo.Session, configs ...Option) *MongoCache {
 }
 
 // EnableStartGC enables the garbage collector in MongoCache struct
+// usage:
+// NewMongoCacheWithTTL(mongoSession, EnableStartGC())
 func EnableStartGC() Option {
 	return optionStartGC(true)
 }
 
 // DisableStartGC disables the garbage collector in MongoCache struct
+// usage:
+// NewMongoCacheWithTTL(mongoSession, DisableStartGC())
 func DisableStartGC() Option {
 	return optionStartGC(false)
 }
@@ -100,6 +104,8 @@ func optionStartGC(b bool) Option {
 }
 
 // SetTTL sets the ttl duration in MongoCache as option
+// usage:
+// NewMongoCacheWithTTL(mongoSession, SetTTL(time*Minute))
 func SetTTL(duration time.Duration) Option {
 	return func(m *MongoCache) {
 		m.TTL = duration
@@ -107,6 +113,8 @@ func SetTTL(duration time.Duration) Option {
 }
 
 // SetGCInterval sets the garbage collector interval in MongoCache struct as option
+// usage:
+// NewMongoCacheWithTTL(mongoSession, SetGCInterval(time*Minute))
 func SetGCInterval(duration time.Duration) Option {
 	return func(m *MongoCache) {
 		m.GCInterval = duration
@@ -114,6 +122,8 @@ func SetGCInterval(duration time.Duration) Option {
 }
 
 // SetCollectionName sets the collection name for mongoDB in MongoCache struct as option
+// usage:
+// NewMongoCacheWithTTL(mongoSession, SetCollectionName("mongoCollName"))
 func SetCollectionName(collName string) Option {
 	return func(m *MongoCache) {
 		m.CollectionName = collName

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -84,12 +84,12 @@ func NewMongoCacheWithTTL(session *mgo.Session, configs ...Option) *MongoCache {
 
 // EnableStartGC enables the garbage collector in MongoCache struct
 func EnableStartGC() Option {
-	optionStartGC(true)
+	return optionStartGC(true)
 }
 
 // DisableStartGC disables the garbage collector in MongoCache struct
 func DisableStartGC() Option {
-	optionStartGC(false)
+	return optionStartGC(false)
 }
 
 // optionStartGC chooses the garbage collector option in MongoCache struct

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -167,7 +167,7 @@ func (m *MongoCache) Delete(key string) error {
 
 func (m *MongoCache) set(key string, value interface{}) error {
 	kv := &KeyValue{
-		ObjectId:  bson.NewObjectId(),
+		ObjectID:  bson.NewObjectId(),
 		Key:       key,
 		Value:     value,
 		CreatedAt: time.Now().UTC(),

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -162,7 +162,7 @@ func (m *MongoCache) Set(key string, value interface{}) error {
 
 // Delete deletes a given key if exists
 func (m *MongoCache) Delete(key string) error {
-	return m.DeleteKey(key)
+	return m.deleteKey(key)
 }
 
 func (m *MongoCache) set(key string, value interface{}) error {
@@ -174,13 +174,13 @@ func (m *MongoCache) set(key string, value interface{}) error {
 		ExpireAt:  time.Now().UTC().Add(m.TTL),
 	}
 
-	return m.CreateKeyValueWithExpiration(kv)
+	return m.createKeyValueWithExpiration(kv)
 }
 
 // extractValue extracts the value inside from struct and returns its value
 // instead of returning all struct
 func (m *MongoCache) extractValue(key string) (interface{}, error) {
-	data, err := m.GetKeyWithExpireCheck(key)
+	data, err := m.getKeyWithExpireCheck(key)
 	if err != nil {
 		return nil, err
 	}
@@ -208,7 +208,7 @@ func (m *MongoCache) StartGCollector(gcInterval time.Duration) {
 			select {
 			case <-ticker.C:
 				m.Lock()
-				m.DeleteExpiredKeys()
+				m.deleteExpiredKeys()
 				m.Unlock()
 			case <-done:
 				return

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -112,8 +112,7 @@ func MustEnsureIndexExpireAt() Option {
 // EnsureIndex ensures the index with expireAt key
 func (m *MongoCache) EnsureIndex() error {
 	query := func(c *mgo.Collection) error {
-		_, err := c.EnsureIndexKey(indexExpireAt)
-		return err
+		return c.EnsureIndexKey(indexExpireAt)
 	}
 
 	return m.run(m.CollectionName, query)

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -109,15 +109,6 @@ func MustEnsureIndexExpireAt() Option {
 	}
 }
 
-// EnsureIndex ensures the index with expireAt key
-func (m *MongoCache) EnsureIndex() error {
-	query := func(c *mgo.Collection) error {
-		return c.EnsureIndexKey(indexExpireAt)
-	}
-
-	return m.run(m.CollectionName, query)
-}
-
 // StartGC enables the garbage collector in MongoCache struct
 // usage:
 // NewMongoCacheWithTTL(mongoSession, StartGC())
@@ -183,6 +174,15 @@ func (m *MongoCache) SetEx(key string, duration time.Duration, value interface{}
 // Delete deletes a given key if exists
 func (m *MongoCache) Delete(key string) error {
 	return m.delete(key)
+}
+
+// EnsureIndex ensures the index with expireAt key
+func (m *MongoCache) EnsureIndex() error {
+	query := func(c *mgo.Collection) error {
+		return c.EnsureIndexKey(indexExpireAt)
+	}
+
+	return m.run(m.CollectionName, query)
 }
 
 // StartGC starts the garbage collector with given time interval The

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -7,11 +7,10 @@ import (
 	mgo "gopkg.in/mgo.v2"
 )
 
-// MongoCache ...
+// MongoCache holds the cache values that will be stored in mongoDB
 type MongoCache struct {
 	mongeSession *mgo.Session
 	// cache holds the cache data
-	// cache *KeyValue
 
 	CollectionName string
 	// ttl is a duration for a cache key to expire
@@ -89,6 +88,7 @@ func (m *MongoCache) set(key string, value interface{}) error {
 	return m.CreateKeyValueWithExpiration(kv)
 }
 
+// StartGCol starts the garbage collector with given time interval
 func (m *MongoCache) StartGCol(gcInterval time.Duration) {
 	if gcInterval <= 0 {
 		return
@@ -114,4 +114,16 @@ func (m *MongoCache) StartGCol(gcInterval time.Duration) {
 			}
 		}
 	}()
+}
+
+// StopGC stops sweeping goroutine.
+func (r *MemoryTTL) StopGCol() {
+	if r.gcTicker != nil {
+		r.Lock()
+		r.gcTicker.Stop()
+		r.gcTicker = nil
+		close(r.done)
+		r.done = nil
+		r.Unlock()
+	}
 }

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -217,14 +217,14 @@ func (m *MongoCache) StartGCollector(gcInterval time.Duration) {
 	}()
 }
 
-// StopGC stops sweeping goroutine.
-func (r *MemoryTTL) StopGCol() {
-	if r.gcTicker != nil {
-		r.Lock()
-		r.gcTicker.Stop()
-		r.gcTicker = nil
-		close(r.done)
-		r.done = nil
-		r.Unlock()
+// StopGCol stops sweeping goroutine.
+func (m *MongoCache) StopGCol() {
+	if m.gcTicker != nil {
+		m.Lock()
+		m.gcTicker.Stop()
+		m.gcTicker = nil
+		close(m.done)
+		m.done = nil
+		m.Unlock()
 	}
 }

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -61,7 +61,7 @@ type option func(*MongoCache)
 // NewMongoCacheWithTTL(session, func(m *MongoCache) {
 // m.CollectionName = "MongoCacheCollectionName"
 // })
-func NewMongoCacheWithTTL(session *mgo.Session, configs ...option) Cache {
+func NewMongoCacheWithTTL(session *mgo.Session, configs ...option) *MongoCache {
 	mc := &MongoCache{
 		mongeSession:   session,
 		TTL:            defaultExpireDuration,

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -96,7 +96,6 @@ func DisableStartGC() Option {
 func optionStartGC(b bool) Option {
 	return func(m *MongoCache) {
 		m.StartGC = b
-
 	}
 }
 
@@ -104,7 +103,6 @@ func optionStartGC(b bool) Option {
 func SetTTL(duration time.Duration) Option {
 	return func(m *MongoCache) {
 		m.TTL = duration
-
 	}
 }
 
@@ -112,7 +110,6 @@ func SetTTL(duration time.Duration) Option {
 func SetGCInterval(duration time.Duration) Option {
 	return func(m *MongoCache) {
 		m.GCInterval = duration
-
 	}
 }
 
@@ -120,7 +117,6 @@ func SetGCInterval(duration time.Duration) Option {
 func SetCollectionName(collName string) Option {
 	return func(m *MongoCache) {
 		m.CollectionName = collName
-
 	}
 }
 

--- a/mongo_cache.go
+++ b/mongo_cache.go
@@ -83,7 +83,7 @@ func (m *MongoCache) set(key string, value interface{}) error {
 		Key:       key,
 		Value:     value,
 		CreatedAt: time.Now().UTC(),
-		ExpireAt:  time.Now().UTC().Add(m.ttl),
+		ExpireAt:  time.Now().UTC().Add(m.TTL),
 	}
 
 	return m.CreateKeyValueWithExpiration(kv)

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -163,3 +163,32 @@ func TestMongoCacheDelete(t *testing.T) {
 		t.Fatal("err should be nil, but got", err)
 	}
 }
+
+func TestMongoCacheTTL(t *testing.T) {
+	// duration specifies the time duration to hold the data in mongo
+	// after the duration interval, data will be deleted from mongoDB
+	duration := time.Second * 20
+	defaultConfig := NewMongoCacheWithTTL(session, SetTTL(duration))
+	if defaultConfig == nil {
+		t.Fatal("config should not be nil")
+	}
+	key := bson.NewObjectId().Hex()
+	value := bson.NewObjectId().Hex()
+
+	err := defaultConfig.Set(key, value)
+	if err != nil {
+		t.Fatal("error should be nil:", err)
+	}
+	data, err := defaultConfig.Get(key)
+	if err != nil {
+		t.Fatal("error should be nil:", err)
+	}
+	if data != value {
+		t.Fatal("data should equal:", value, ", but got:", data)
+	}
+	time.Sleep(duration)
+	_, err = defaultConfig.Get(key)
+	if err != mgo.ErrNotFound {
+		t.Fatal("error should equal", mgo.ErrNotFound, " but got:", err)
+	}
+}

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"testing"
 	"time"
 
 	mgo "gopkg.in/mgo.v2"
@@ -27,7 +28,7 @@ var (
 	}
 )
 
-func TestMongoCacheConfig() {
+func TestMongoCacheConfig(t *testing.T) {
 	defaultConfig := NewMongoCacheWithTTL(defaultSession)
 	if defaultConfig == nil {
 		t.Fatal("config should not be nil")

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -1,8 +1,14 @@
 package cache
 
-import "time"
+import (
+	"time"
+
+	mgo "gopkg.in/mgo.v2"
+)
 
 var (
+	defaultSession = &mgo.Session{}
+
 	// config options for MongoCache
 	ttl = func(m *MongoCache) {
 		m.TTL = 2 * time.Minute
@@ -22,18 +28,18 @@ var (
 )
 
 func TestMongoCacheConfig() {
-	defaultConfig := NewMongoCacheWithTTL(session)
+	defaultConfig := NewMongoCacheWithTTL(defaultSession)
 	if defaultConfig == nil {
 		t.Fatal("config should not be nil")
 	}
-	configTTL := NewMongoCacheWithTTL(session, ttl)
+	configTTL := NewMongoCacheWithTTL(defaultSession, ttl)
 	if configTTL == nil {
 		t.Fatal("ttl config should not be nil")
 	}
 	if configTTL.TTL != time.Minute*2 {
 		t.Fatal("config ttl time should equal 2 minutes")
 	}
-	config := NewMongoCacheWithTTL(session, collection, startGC)
+	config := NewMongoCacheWithTTL(defaultSession, collection, startGC)
 	if config == nil {
 		t.Fatal("config should not be nil")
 	}

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -135,3 +135,31 @@ func TestMongoCacheSet(t *testing.T) {
 		t.Fatal("data should equal:", value, ", but got:", data)
 	}
 }
+
+func TestMongoCacheDelete(t *testing.T) {
+	defaultConfig := NewMongoCacheWithTTL(session)
+	if defaultConfig == nil {
+		t.Fatal("config should not be nil")
+	}
+	key := bson.NewObjectId().Hex()
+	value := bson.NewObjectId().Hex()
+
+	err := defaultConfig.Set(key, value)
+	if err != nil {
+		t.Fatal("error should be nil:", err)
+	}
+	data, err := defaultConfig.Get(key)
+	if err != nil {
+		t.Fatal("error should be nil:", err)
+	}
+	if data == nil {
+		t.Fatal("data should not be nil")
+	}
+	if data != value {
+		t.Fatal("data should equal:", value, ", but got:", data)
+	}
+	err = defaultConfig.Delete(key)
+	if err != nil {
+		t.Fatal("err should be nil, but got", err)
+	}
+}

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -167,7 +167,7 @@ func TestMongoCacheDelete(t *testing.T) {
 func TestMongoCacheTTL(t *testing.T) {
 	// duration specifies the time duration to hold the data in mongo
 	// after the duration interval, data will be deleted from mongoDB
-	duration := time.Second * 20
+	duration := time.Second * 10
 	defaultConfig := NewMongoCacheWithTTL(session, SetTTL(duration))
 	if defaultConfig == nil {
 		t.Fatal("config should not be nil")

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -51,3 +51,36 @@ func TestMongoCacheConfig(t *testing.T) {
 		t.Fatal("config StartGC option should not be true")
 	}
 }
+
+func TestMongoSetOptionFuncs(t *testing.T) {
+	defaultConfig := NewMongoCacheWithTTL(defaultSession)
+	if defaultConfig == nil {
+		t.Fatal("config should not be nil")
+	}
+
+	duration := time.Minute * 3
+	configTTL := NewMongoCacheWithTTL(defaultSession, SetTTL(duration))
+	if configTTL == nil {
+		t.Fatal("ttl config should not be nil")
+	}
+	if configTTL.TTL != duration {
+		t.Fatal("config ttl time should equal 2 minutes")
+	}
+
+	// check multiple options
+	collName := "testingCollectionName"
+	config := NewMongoCacheWithTTL(defaultSession, SetCollectionName(collName), SetGCInterval(duration), EnableStartGC())
+	if config == nil {
+		t.Fatal("config should not be nil")
+	}
+	if config.CollectionName != collName {
+		t.Fatal("config collection name should equal 'TestCollectionName'")
+	}
+	if config.StartGC != true {
+		t.Fatal("config StartGC option should not be true")
+	}
+
+	if config.GCInterval != duration {
+		t.Fatal("config GCInterval option should equal", duration)
+	}
+}

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -1,0 +1,46 @@
+package cache
+
+import "time"
+
+var (
+	// config options for MongoCache
+	ttl = func(m *MongoCache) {
+		m.TTL = 2 * time.Minute
+	}
+
+	collection = func(m *MongoCache) {
+		m.CollectionName = "TestCollectionName"
+	}
+
+	gcInterval = func(m *MongoCache) {
+		m.GCInterval = 2 * time.Minute
+	}
+
+	startGC = func(m *MongoCache) {
+		m.StartGC = true
+	}
+)
+
+func TestMongoCacheConfig() {
+	defaultConfig := NewMongoCacheWithTTL(session)
+	if defaultConfig == nil {
+		t.Fatal("config should not be nil")
+	}
+	configTTL := NewMongoCacheWithTTL(session, ttl)
+	if configTTL == nil {
+		t.Fatal("ttl config should not be nil")
+	}
+	if configTTL.TTL != time.Minute*2 {
+		t.Fatal("config ttl time should equal 2 minutes")
+	}
+	config := NewMongoCacheWithTTL(session, collection, startGC)
+	if config == nil {
+		t.Fatal("config should not be nil")
+	}
+	if config.CollectionName != "TestCollectionName" {
+		t.Fatal("config collection name should equal 'TestCollectionName'")
+	}
+	if config.StartGC != true {
+		t.Fatal("config StartGC option should not be true")
+	}
+}

--- a/mongo_cache_test.go
+++ b/mongo_cache_test.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -9,8 +10,8 @@ import (
 )
 
 var (
-	defaultSession = &mgo.Session{}
-
+	defSes = &mgo.Session{}
+	// session is the default session with default options
 	session = initMongo()
 
 	// config options for MongoCache
@@ -27,54 +28,42 @@ var (
 	}
 
 	startGC = func(m *MongoCache) {
-		m.StartGC = true
+		m.GCStart = true
 	}
 )
 
-func initMongo() *mgo.Session {
-	ses, err := mgo.Dial("127.0.0.1:27017/test")
-	if err != nil {
-		panic(err)
-	}
-
-	ses.SetSafe(&mgo.Safe{})
-	ses.SetMode(mgo.Strong, true)
-
-	return ses
-}
-
 func TestMongoCacheConfig(t *testing.T) {
-	defaultConfig := NewMongoCacheWithTTL(session)
-	if defaultConfig == nil {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
-	configTTL := NewMongoCacheWithTTL(defaultSession, ttl)
+	configTTL := NewMongoCacheWithTTL(session, ttl)
 	if configTTL == nil {
 		t.Fatal("ttl config should not be nil")
 	}
 	if configTTL.TTL != time.Minute*2 {
 		t.Fatal("config ttl time should equal 2 minutes")
 	}
-	config := NewMongoCacheWithTTL(defaultSession, collection, startGC)
+	config := NewMongoCacheWithTTL(session, collection, startGC)
 	if config == nil {
 		t.Fatal("config should not be nil")
 	}
 	if config.CollectionName != "TestCollectionName" {
 		t.Fatal("config collection name should equal 'TestCollectionName'")
 	}
-	if config.StartGC != true {
+	if config.GCStart != true {
 		t.Fatal("config StartGC option should not be true")
 	}
 }
 
 func TestMongoCacheSetOptionFuncs(t *testing.T) {
-	defaultConfig := NewMongoCacheWithTTL(defaultSession)
-	if defaultConfig == nil {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
 
 	duration := time.Minute * 3
-	configTTL := NewMongoCacheWithTTL(defaultSession, SetTTL(duration))
+	configTTL := NewMongoCacheWithTTL(session, SetTTL(duration))
 	if configTTL == nil {
 		t.Fatal("ttl config should not be nil")
 	}
@@ -84,47 +73,45 @@ func TestMongoCacheSetOptionFuncs(t *testing.T) {
 
 	// check multiple options
 	collName := "testingCollectionName"
-	config := NewMongoCacheWithTTL(defaultSession, SetCollectionName(collName), SetGCInterval(duration), EnableStartGC())
+	config := NewMongoCacheWithTTL(session, SetCollectionName(collName), SetGCInterval(duration), StartGC())
 	if config == nil {
 		t.Fatal("config should not be nil")
 	}
 	if config.CollectionName != collName {
 		t.Fatal("config collection name should equal 'TestCollectionName'")
 	}
-	if config.StartGC != true {
+	if config.GCStart != true {
 		t.Fatal("config StartGC option should not be true")
 	}
 
 	if config.GCInterval != duration {
-		t.Fatal("config GCInterval option should equal", duration)
+		t.Fatalf("config GCInterval option should equal %v", duration)
 	}
 }
 
 func TestMongoCacheGet(t *testing.T) {
-	defaultConfig := NewMongoCacheWithTTL(session)
-	if defaultConfig == nil {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
-
-	_, err := defaultConfig.Get("test")
-	if err != mgo.ErrNotFound {
-		t.Fatal("error is:", err)
+	if _, err := mgoCache.Get("test"); err != ErrNotFound {
+		t.Fatalf("error is: %q", err)
 	}
 }
 
 func TestMongoCacheSet(t *testing.T) {
-	defaultConfig := NewMongoCacheWithTTL(session)
-	if defaultConfig == nil {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
 	key := bson.NewObjectId().Hex()
 	value := bson.NewObjectId().Hex()
 
-	err := defaultConfig.Set(key, value)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
+	if err := mgoCache.Set(key, value); err != nil {
+		t.Fatalf("error should be nil: %q", err)
 	}
-	data, err := defaultConfig.Get(key)
+
+	data, err := mgoCache.Get(key)
 	if err != nil {
 		t.Fatal("error should be nil:", err)
 	}
@@ -132,64 +119,98 @@ func TestMongoCacheSet(t *testing.T) {
 		t.Fatal("data should not be nil")
 	}
 	if data != value {
-		t.Fatal("data should equal:", value, ", but got:", data)
+		t.Fatalf("data should equal: %v ,but got: %v", value, data)
 	}
 }
 
+func TestMongoCacheSetEx(t *testing.T) {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
+		t.Fatal("config should not be nil")
+	}
+	// defaultExpireDuration is 1 Minute as default
+	if mgoCache.TTL != defaultExpireDuration {
+		t.Fatalf("mongoCache TTL should equal %v", defaultExpireDuration)
+	}
+
+	key := bson.NewObjectId().Hex()
+	value := bson.NewObjectId().Hex()
+
+	duration := time.Second * 10
+	err := mgoCache.SetEx(key, duration, value)
+	if err != nil {
+		t.Fatalf("error should be nil: %q", err)
+	}
+
+	document, err := mgoCache.get(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !time.Now().Add(duration).After(document.ExpireAt) {
+		t.Fatalf("expireAt should less than %v", duration)
+	}
+
+}
+
 func TestMongoCacheDelete(t *testing.T) {
-	defaultConfig := NewMongoCacheWithTTL(session)
-	if defaultConfig == nil {
+	mgoCache := NewMongoCacheWithTTL(session)
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
 	key := bson.NewObjectId().Hex()
 	value := bson.NewObjectId().Hex()
 
-	err := defaultConfig.Set(key, value)
+	err := mgoCache.Set(key, value)
 	if err != nil {
-		t.Fatal("error should be nil:", err)
+		t.Fatalf("error should be nil: %q", err)
 	}
-	data, err := defaultConfig.Get(key)
+	data, err := mgoCache.Get(key)
 	if err != nil {
-		t.Fatal("error should be nil:", err)
+		t.Fatalf("error should be nil: %q", err)
 	}
 	if data == nil {
 		t.Fatal("data should not be nil")
 	}
 	if data != value {
-		t.Fatal("data should equal:", value, ", but got:", data)
+		t.Fatalf("data should equal to %v, but got: %v", value, data)
 	}
-	err = defaultConfig.Delete(key)
-	if err != nil {
-		t.Fatal("err should be nil, but got", err)
+
+	if err = mgoCache.Delete(key); err != nil {
+		t.Fatalf("err should be nil, but got %q", err)
+	}
+
+	if _, err := mgoCache.Get(key); err != ErrNotFound {
+		t.Fatalf("error should equal to %q but got: %q", ErrNotFound, err)
 	}
 }
 
 func TestMongoCacheTTL(t *testing.T) {
 	// duration specifies the time duration to hold the data in mongo
 	// after the duration interval, data will be deleted from mongoDB
-	duration := time.Second * 10
-	defaultConfig := NewMongoCacheWithTTL(session, SetTTL(duration))
-	if defaultConfig == nil {
+	duration := time.Millisecond * 100
+
+	mgoCache := NewMongoCacheWithTTL(session, SetTTL(duration))
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
-	key := bson.NewObjectId().Hex()
-	value := bson.NewObjectId().Hex()
+	defer mgoCache.StopGC()
 
-	err := defaultConfig.Set(key, value)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
+	key, value := bson.NewObjectId().Hex(), bson.NewObjectId().Hex()
+
+	if err := mgoCache.Set(key, value); err != nil {
+		t.Fatalf("error should be nil: %q", err)
 	}
-	data, err := defaultConfig.Get(key)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
+
+	if data, err := mgoCache.Get(key); err != nil {
+		t.Fatalf("error should be nil: %q", err)
+	} else if data != value {
+		t.Fatalf("data should equal: %v, but got: %v", value, data)
 	}
-	if data != value {
-		t.Fatal("data should equal:", value, ", but got:", data)
-	}
+
 	time.Sleep(duration)
-	_, err = defaultConfig.Get(key)
-	if err != mgo.ErrNotFound {
-		t.Fatal("error should equal", mgo.ErrNotFound, " but got:", err)
+
+	if _, err := mgoCache.Get(key); err != ErrNotFound {
+		t.Fatalf("error should equal to %q but got: %q", ErrNotFound, err)
 	}
 }
 
@@ -198,46 +219,80 @@ func TestMongoCacheTTL(t *testing.T) {
 func TestMongoCacheGC(t *testing.T) {
 	// duration specifies the time duration to hold the data in mongo
 	// after the duration interval, data will be deleted from mongoDB
-	duration := time.Second * 10
-	defaultConfig := NewMongoCacheWithTTL(session, SetTTL(duration/2), SetGCInterval(duration), EnableStartGC())
-	if defaultConfig == nil {
+	duration := time.Millisecond * 100
+
+	mgoCache := NewMongoCacheWithTTL(session, SetTTL(duration/2), SetGCInterval(duration), StartGC())
+	if mgoCache == nil {
 		t.Fatal("config should not be nil")
 	}
-	key := bson.NewObjectId().Hex()
-	value := bson.NewObjectId().Hex()
-	key1 := bson.NewObjectId().Hex()
-	value1 := bson.NewObjectId().Hex()
 
-	err := defaultConfig.Set(key, value)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
-	}
-	err = defaultConfig.Set(key1, value1)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
-	}
-	data, err := defaultConfig.Get(key)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
-	}
-	if data != value {
-		t.Fatal("data should equal:", value, ", but got:", data)
-	}
-	data1, err := defaultConfig.Get(key1)
-	if err != nil {
-		t.Fatal("error should be nil:", err)
-	}
-	if data1 != value1 {
-		t.Fatal("data should equal:", value1, ", but got:", data1)
-	}
-	time.Sleep(duration * 2)
+	defer mgoCache.StopGC()
 
-	_, err = defaultConfig.Get(key)
-	if err != mgo.ErrNotFound {
-		t.Fatal("error should equal", mgo.ErrNotFound, " but got:", err)
+	key, value := bson.NewObjectId().Hex(), bson.NewObjectId().Hex()
+	key1, value1 := bson.NewObjectId().Hex(), bson.NewObjectId().Hex()
+
+	if err := mgoCache.Set(key, value); err != nil {
+		t.Fatalf("error should be nil: %q", err)
 	}
-	_, err = defaultConfig.Get(key1)
-	if err != mgo.ErrNotFound {
-		t.Fatal("error should equal", mgo.ErrNotFound, " but got:", err)
+	if err := mgoCache.Set(key1, value1); err != nil {
+		t.Fatalf("error should be nil: %q", err)
 	}
+
+	if data, err := mgoCache.Get(key); err != nil {
+		t.Fatalf("error should be nil: %q", err)
+	} else if data != value {
+		t.Fatalf("data should equal: %v, but got: %v", value, data)
+	}
+
+	if data1, err := mgoCache.Get(key1); err != nil {
+		t.Fatalf("error should be nil: %q", err)
+	} else if data1 != value1 {
+		t.Fatalf("data should equal: %v, but got: %v", value1, data1)
+	}
+
+	time.Sleep(duration)
+
+	docs, err := getAllDocuments(mgoCache, key1, key1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(docs) != 0 {
+		t.Fatalf("len should equal to 0 but got: %d", len(docs))
+	}
+}
+
+func getAllDocuments(mgoCache *MongoCache, keys ...string) ([]Document, error) {
+	var docs []Document
+	query := func(c *mgo.Collection) error {
+		return c.Find(bson.M{
+			"_id": bson.M{
+				"$in": keys,
+			},
+		}).All(&docs)
+	}
+
+	err := mgoCache.run(mgoCache.CollectionName, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return docs, nil
+}
+
+func initMongo() *mgo.Session {
+	mongoURI := os.Getenv("MONGODB_URL")
+	if mongoURI == "" {
+		mongoURI = "127.0.0.1:27017/test"
+	}
+
+	ses, err := mgo.Dial(mongoURI)
+	if err != nil {
+		panic(err)
+	}
+
+	ses.SetSafe(&mgo.Safe{})
+	ses.SetMode(mgo.Strong, true)
+
+	return ses
 }

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -20,7 +20,7 @@ var (
 )
 
 // keyValueColl default collection name for mongoDB
-const keyValueColl = "jKeyValue"
+const defaultKeyValueColl = "jKeyValue"
 
 // CreateKeyValue c
 func (m *MongoCache) CreateKeyValue(k *KeyValue) error {
@@ -56,7 +56,7 @@ func (m *MongoCache) GetKey(key string) (*KeyValue, error) {
 		return c.Find(bson.M{"key": key}).One(&keyValue)
 	}
 
-	err := m.run(keyValueColl, query)
+	err := m.run(m.CollectionName, query)
 	if err != nil {
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (m *MongoCache) UpdateKey(selector, update bson.M) error {
 		return c.Update(selector, bson.M{"$set": update})
 	}
 
-	return m.run(keyValueColl, query)
+	return m.run(m.CollectionName, query)
 }
 
 // DeleteKey removes the key-value from mongoDB
@@ -82,7 +82,7 @@ func (m *MongoCache) DeleteKey(key string) error {
 		return err
 	}
 
-	return m.run(keyValueColl, query)
+	return m.run(m.CollectionName, query)
 }
 
 func (m *MongoCache) DeleteExpiredKeys() error {
@@ -95,13 +95,13 @@ func (m *MongoCache) DeleteExpiredKeys() error {
 		return err
 	}
 
-	return m.run(keyValueColl, query)
+	return m.run(m.CollectionName, query)
 }
 
 func (m *MongoCache) createKeyValue(k *KeyValue) error {
 	k.CreatedAt = time.Now().UTC()
 	query := insertQuery(k)
-	return m.run(keyValueColl, query)
+	return m.run(m.CollectionName, query)
 }
 
 func setDefaultDataTimes(k *KeyValue) *KeyValue {

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -1,0 +1,135 @@
+package cache
+
+import (
+	"koding/db/models"
+	"time"
+
+	"gopkg.in/mgo.v2/bson"
+)
+
+type KeyValue struct {
+	ObjectId  bson.ObjectId `bson:"_id" json:"_id"`
+	Key       string        `bson:"key" json:"key"`
+	Value     interface{}   `bson:"value" json:"value"`
+	CreatedAt time.Time     `bson:"createdAt" json:"createdAt"`
+	ExpireAt  time.Time     `bson:"expireAt" json:"expireAt"`
+}
+
+// KeyValueColl default collection name for mongoDB
+const KeyValueColl = "jKeyValue"
+
+// CreateKeyValue c
+func (m *MongoCache) CreateKeyValue(k *KeyValue) error {
+	return m.CreateKeyValue(k)
+}
+
+// CreateKeyValueWithExpiration creates the key-value pair with default time constants
+func (m *MongoCache) CreateKeyValueWithExpiration(k *KeyValue) error {
+	return m.createKeyValue(setDefaultDataTimes(k))
+}
+
+func (m *MongoCache) GetKeyWithExpireCheck(k string) (*KeyValue, error) {
+	key, err := m.GetKey(k)
+	if err != nil {
+		return nil, err
+	}
+
+	if key.ExpireAt.Before(time.Now().UTC()) {
+		if err := m.DeleteKey(k); err != nil {
+			return nil, err
+		}
+		return nil, mgo.ErrNotFound
+	}
+
+	return key, nil
+}
+
+// GetKey fetches the key with its key
+func (m *MongoCache) GetKey(key string) (*KeyValue, error) {
+	keyValue := new(models.KeyValue)
+
+	query := func(c *mgo.Collection) error {
+		return c.Find(bson.M{"key": key}).One(&keyValue)
+	}
+
+	err := m.run(KeyValueColl, query)
+	if err != nil {
+		return nil, err
+	}
+
+	return keyValue, nil
+}
+
+// UpdateKey updates the key-value in mongoDB
+func (m *MongoCache) UpdateKey(selector, update bson.M) error {
+	query := func(c *mgo.Collection) error {
+		return c.Update(selector, bson.M{"$set": update})
+	}
+
+	return m.run(KeyValueColl, query)
+}
+
+// DeleteKey removes the key-value from mongoDB
+func (m *MongoCache) DeleteKey(key string) error {
+	selector := bson.M{"key": key}
+
+	query := func(c *mgo.Collection) error {
+		err := c.Remove(selector)
+		return err
+	}
+
+	return m.run(KeyValueColl, query)
+}
+
+func (m *MongoCache) createKeyValue(k *KeyValue) error {
+	k.CreatedAt = time.Now().UTC()
+	query := insertQuery(k)
+	return m.run(KeyValueColl, query)
+}
+
+func setDefaultDataTimes(k *KeyValue) *KeyValue {
+	if k.CreatedAt.IsZero() {
+		k.CreatedAt = time.Now().UTC()
+	}
+
+	// ExpireAt should be in the future as time
+	if k.ExpireAt.Before(time.Now().UTC()) || k.ExpireAt.IsZero() {
+		k.ExpireAt = k.CreatedAt.Add(defaultExpireDuration)
+	}
+
+	return k
+}
+
+func insertQuery(data interface{}) func(*mgo.Collection) error {
+	return func(c *mgo.Collection) error {
+		return c.Insert(data)
+	}
+}
+
+//
+// MongoDB helper functions
+// no need to be exported functions
+//
+
+func (m *MongoCache) close() {
+	m.mongeSession.Close()
+}
+
+func (m *MongoCache) refresh() {
+	m.mongeSession.Refresh()
+}
+
+func (m *MongoCache) copy() *mgo.Session {
+	return m.mongeSession.Copy()
+}
+
+func (m *MongoCache) clone() *mgo.Session {
+	return m.mongeSession.Clone()
+}
+
+func (m *MongoCache) run(collection string, s func(*mgo.Collection) error) error {
+	session := m.Copy()
+	defer session.Close()
+	c := session.DB("").C(collection)
+	return s(c)
+}

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -7,8 +7,9 @@ import (
 	"gopkg.in/mgo.v2/bson"
 )
 
+// KeyValue holds the key-value pair for mongo cache
 type KeyValue struct {
-	ObjectId  bson.ObjectId `bson:"_id" json:"_id"`
+	ObjectID  bson.ObjectId `bson:"_id" json:"_id"`
 	Key       string        `bson:"key" json:"key"`
 	Value     interface{}   `bson:"value" json:"value"`
 	CreatedAt time.Time     `bson:"createdAt" json:"createdAt"`
@@ -122,14 +123,6 @@ func insertQuery(data interface{}) func(*mgo.Collection) error {
 // MongoDB helper functions
 // no need to be exported functions
 //
-
-func (m *MongoCache) close() {
-	m.mongeSession.Close()
-}
-
-func (m *MongoCache) refresh() {
-	m.mongeSession.Refresh()
-}
 
 func (m *MongoCache) copy() *mgo.Session {
 	return m.mongeSession.Copy()

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -22,24 +22,19 @@ var (
 // keyValueColl default collection name for mongoDB
 const defaultKeyValueColl = "jKeyValue"
 
-// CreateKeyValue c
-func (m *MongoCache) CreateKeyValue(k *KeyValue) error {
-	return m.createKeyValue(k)
-}
-
 // CreateKeyValueWithExpiration creates the key-value pair with default time constants
-func (m *MongoCache) CreateKeyValueWithExpiration(k *KeyValue) error {
+func (m *MongoCache) createKeyValueWithExpiration(k *KeyValue) error {
 	return m.createKeyValue(setDefaultDataTimes(k))
 }
 
-func (m *MongoCache) GetKeyWithExpireCheck(k string) (*KeyValue, error) {
-	key, err := m.GetKey(k)
+func (m *MongoCache) getKeyWithExpireCheck(k string) (*KeyValue, error) {
+	key, err := m.getKey(k)
 	if err != nil {
 		return nil, err
 	}
 
 	if key.ExpireAt.Before(time.Now().UTC()) {
-		if err := m.DeleteKey(k); err != nil {
+		if err := m.deleteKey(k); err != nil {
 			return nil, err
 		}
 		return nil, mgo.ErrNotFound
@@ -48,8 +43,8 @@ func (m *MongoCache) GetKeyWithExpireCheck(k string) (*KeyValue, error) {
 	return key, nil
 }
 
-// GetKey fetches the key with its key
-func (m *MongoCache) GetKey(key string) (*KeyValue, error) {
+// getKey fetches the key with its key
+func (m *MongoCache) getKey(key string) (*KeyValue, error) {
 	keyValue := new(KeyValue)
 
 	query := func(c *mgo.Collection) error {
@@ -73,8 +68,8 @@ func (m *MongoCache) UpdateKey(selector, update bson.M) error {
 	return m.run(m.CollectionName, query)
 }
 
-// DeleteKey removes the key-value from mongoDB
-func (m *MongoCache) DeleteKey(key string) error {
+// deleteKey removes the key-value from mongoDB
+func (m *MongoCache) deleteKey(key string) error {
 	selector := bson.M{"key": key}
 
 	query := func(c *mgo.Collection) error {
@@ -85,7 +80,7 @@ func (m *MongoCache) DeleteKey(key string) error {
 	return m.run(m.CollectionName, query)
 }
 
-func (m *MongoCache) DeleteExpiredKeys() error {
+func (m *MongoCache) deleteExpiredKeys() error {
 	var selector = bson.M{"expireAt": bson.M{
 		"$lte": time.Now().UTC(),
 	}}

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -15,6 +15,10 @@ type KeyValue struct {
 	ExpireAt  time.Time     `bson:"expireAt" json:"expireAt"`
 }
 
+var (
+	defaultExpireDuration = time.Second * 60
+)
+
 // KeyValueColl default collection name for mongoDB
 const KeyValueColl = "jKeyValue"
 
@@ -121,10 +125,6 @@ func (m *MongoCache) refresh() {
 
 func (m *MongoCache) copy() *mgo.Session {
 	return m.mongeSession.Copy()
-}
-
-func (m *MongoCache) clone() *mgo.Session {
-	return m.mongeSession.Clone()
 }
 
 func (m *MongoCache) run(collection string, s func(*mgo.Collection) error) error {

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -1,9 +1,9 @@
 package cache
 
 import (
-	"koding/db/models"
 	"time"
 
+	mgo "gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
 )
 
@@ -20,7 +20,7 @@ const KeyValueColl = "jKeyValue"
 
 // CreateKeyValue c
 func (m *MongoCache) CreateKeyValue(k *KeyValue) error {
-	return m.CreateKeyValue(k)
+	return m.createKeyValue(k)
 }
 
 // CreateKeyValueWithExpiration creates the key-value pair with default time constants
@@ -46,7 +46,7 @@ func (m *MongoCache) GetKeyWithExpireCheck(k string) (*KeyValue, error) {
 
 // GetKey fetches the key with its key
 func (m *MongoCache) GetKey(key string) (*KeyValue, error) {
-	keyValue := new(models.KeyValue)
+	keyValue := new(KeyValue)
 
 	query := func(c *mgo.Collection) error {
 		return c.Find(bson.M{"key": key}).One(&keyValue)

--- a/mongo_model.go
+++ b/mongo_model.go
@@ -128,7 +128,7 @@ func (m *MongoCache) copy() *mgo.Session {
 }
 
 func (m *MongoCache) run(collection string, s func(*mgo.Collection) error) error {
-	session := m.Copy()
+	session := m.copy()
 	defer session.Close()
 	c := session.DB("").C(collection)
 	return s(c)

--- a/sharded_cache.go
+++ b/sharded_cache.go
@@ -5,14 +5,14 @@ package cache
 type ShardedCache interface {
 	// Get returns single item from the backend if the requested item is not
 	// found, returns NotFound err
-	Get(shardId, key string) (interface{}, error)
+	Get(shardID, key string) (interface{}, error)
 
 	// Set sets a single item to the backend
-	Set(shardId, key string, value interface{}) error
+	Set(shardID, key string, value interface{}) error
 
 	// Delete deletes single item from backend
-	Delete(shardId, key string) error
+	Delete(shardID, key string) error
 
 	// Deletes all items in that shard
-	DeleteShard(shardId string) error
+	DeleteShard(shardID string) error
 }

--- a/sharded_nots.go
+++ b/sharded_nots.go
@@ -1,59 +1,67 @@
 package cache
 
-// The concept behind this storage is that each cache entry is associated with a tenantId
-// and this enables fast purging for just that tenantId
+// ShardedNoTS ; the concept behind this storage is that each cache entry is
+// associated with a tenantID and this enables fast purging for just that
+// tenantID
 type ShardedNoTS struct {
-    cache       map[string]Cache
-    itemCount   map[string]int
-    constructor func() Cache
+	cache       map[string]Cache
+	itemCount   map[string]int
+	constructor func() Cache
 }
 
+// NewShardedNoTS inits ShardedNoTS struct
 func NewShardedNoTS(c func() Cache) *ShardedNoTS {
-    return &ShardedNoTS{
-        constructor: c,
-        cache:       make(map[string]Cache),
-        itemCount:   make(map[string]int),
-    }
+	return &ShardedNoTS{
+		constructor: c,
+		cache:       make(map[string]Cache),
+		itemCount:   make(map[string]int),
+	}
 }
 
-func (l *ShardedNoTS) Get(tenantId, key string) (interface{}, error) {
-    cache, ok := l.cache[tenantId]
-    if !ok {
-        return nil, ErrNotFound
-    }
+// Get returns a value of a given key if it exists
+// and valid for the time being
+func (l *ShardedNoTS) Get(tenantID, key string) (interface{}, error) {
+	cache, ok := l.cache[tenantID]
+	if !ok {
+		return nil, ErrNotFound
+	}
 
-    return cache.Get(key)
+	return cache.Get(key)
 }
 
-func (l *ShardedNoTS) Set(tenantId, key string, val interface{}) error {
-    _, ok := l.cache[tenantId]
-    if !ok {
-        l.cache[tenantId] = l.constructor()
-        l.itemCount[tenantId] = 0
-    }
+// Set will persist a value to the cache or override existing one with the new
+// one
+func (l *ShardedNoTS) Set(tenantID, key string, val interface{}) error {
+	_, ok := l.cache[tenantID]
+	if !ok {
+		l.cache[tenantID] = l.constructor()
+		l.itemCount[tenantID] = 0
+	}
 
-    l.itemCount[tenantId]++
-    return l.cache[tenantId].Set(key, val)
+	l.itemCount[tenantID]++
+	return l.cache[tenantID].Set(key, val)
 }
 
-func (l *ShardedNoTS) Delete(tenantId, key string) error {
-    _, ok := l.cache[tenantId]
-    if !ok {
-        return nil
-    }
+// Delete deletes a given key
+func (l *ShardedNoTS) Delete(tenantID, key string) error {
+	_, ok := l.cache[tenantID]
+	if !ok {
+		return nil
+	}
 
-    l.itemCount[tenantId]--
+	l.itemCount[tenantID]--
 
-    if l.itemCount[tenantId] == 0 {
-        return l.DeleteShard(tenantId)
-    }
+	if l.itemCount[tenantID] == 0 {
+		return l.DeleteShard(tenantID)
+	}
 
-    return l.cache[tenantId].Delete(key)
+	return l.cache[tenantID].Delete(key)
 }
 
-func (l *ShardedNoTS) DeleteShard(tenantId string) error {
-    delete(l.cache, tenantId)
-    delete(l.itemCount, tenantId)
+// DeleteShard deletes the keys inside from maps of cache & itemCount
+func (l *ShardedNoTS) DeleteShard(tenantID string) error {
+	delete(l.cache, tenantID)
+	delete(l.itemCount, tenantID)
 
-    return nil
+	return nil
 }


### PR DESCRIPTION
Cache structure that written for mongoDB

In this package, mongoCache helper functions and its methods are created as unexported functions. We dont need to show them to user because this package is written for cache logic(get-set-delete).
Also all required cache functions(get-set-delete), handles whole background logic (handles ttl, enabling garbage collector for mongodb, option exported function to stopping GC etc..).